### PR TITLE
check whether executable compiled successfully

### DIFF
--- a/fishbuilder.py
+++ b/fishbuilder.py
@@ -74,8 +74,11 @@ def individualToParameters(individual):
 #Evaluation function, keep the best sample of the bench
 def evalOneMax(individual):
     executable=build(individualToParameters(individual))
-    fitness=max(benchEngine(executable,3))
-    os.remove(executable)
+    if os.path.isfile(executable):
+        fitness=max(benchEngine(executable,3))
+        os.remove(executable)
+    else:
+	fitness=0
     return [fitness]
 
 #Launch the genetic algorithm loop


### PR DESCRIPTION
Some compiler options may prevent the programm from compiling at all. Previously that would abort the evolution run with a file not found error. Catch these cases and assign them a fitness value of 0.